### PR TITLE
Added history heuristic for sorting quiet moves

### DIFF
--- a/src/swizzles/search/qsearch.cpp
+++ b/src/swizzles/search/qsearch.cpp
@@ -5,7 +5,7 @@
 
 namespace swizzles::search {
 
-[[nodiscard]] auto qsearch(chess::Position &pos, int alpha, const int beta, const ThreadData &td) noexcept -> int {
+[[nodiscard]] auto qsearch(const ThreadData &td, chess::Position &pos, int alpha, const int beta) noexcept -> int {
     const auto stand_pat = eval::eval(pos);
 
     if (stand_pat >= beta) {
@@ -21,7 +21,7 @@ namespace swizzles::search {
 
     for (const auto move : moves) {
         pos.makemove(move);
-        const auto score = -qsearch(pos, -beta, -alpha, td);
+        const auto score = -qsearch(td, pos, -beta, -alpha);
         pos.undomove();
 
         if (score >= beta) {

--- a/src/swizzles/search/qsearch.cpp
+++ b/src/swizzles/search/qsearch.cpp
@@ -5,7 +5,7 @@
 
 namespace swizzles::search {
 
-[[nodiscard]] auto qsearch(chess::Position &pos, int alpha, const int beta) noexcept -> int {
+[[nodiscard]] auto qsearch(chess::Position &pos, int alpha, const int beta, const ThreadData &td) noexcept -> int {
     const auto stand_pat = eval::eval(pos);
 
     if (stand_pat >= beta) {
@@ -17,12 +17,11 @@ namespace swizzles::search {
     }
 
     auto moves = pos.captures();
-
-    sort(moves, chess::Move());
+    sort(moves, chess::Move(), td, pos.turn());
 
     for (const auto move : moves) {
         pos.makemove(move);
-        const auto score = -qsearch(pos, -beta, -alpha);
+        const auto score = -qsearch(pos, -beta, -alpha, td);
         pos.undomove();
 
         if (score >= beta) {

--- a/src/swizzles/search/qsearch.hpp
+++ b/src/swizzles/search/qsearch.hpp
@@ -7,7 +7,7 @@ class Position;
 
 namespace swizzles::search {
 
-[[nodiscard]] auto qsearch(chess::Position &pos, int alpha, const int beta) noexcept -> int;
+[[nodiscard]] auto qsearch(chess::Position &pos, int alpha, const int beta, const ThreadData &td) noexcept -> int;
 
 }  // namespace swizzles::search
 

--- a/src/swizzles/search/qsearch.hpp
+++ b/src/swizzles/search/qsearch.hpp
@@ -7,7 +7,7 @@ class Position;
 
 namespace swizzles::search {
 
-[[nodiscard]] auto qsearch(chess::Position &pos, int alpha, const int beta, const ThreadData &td) noexcept -> int;
+[[nodiscard]] auto qsearch(const ThreadData &td, chess::Position &pos, int alpha, const int beta) noexcept -> int;
 
 }  // namespace swizzles::search
 

--- a/src/swizzles/search/search.cpp
+++ b/src/swizzles/search/search.cpp
@@ -115,9 +115,10 @@ namespace swizzles::search {
 
         alpha = std::max(alpha, score);
         if (alpha >= beta) {
-            if (move.captured() == chess::PieceType::None)
+            if (move.captured() == chess::PieceType::None && depth < 64) {
                 td.history_score[chess::index(pos.turn())][chess::index(move.from())][chess::index(move.to())] +=
                     1ULL << depth;
+            }
             break;
         }
     }

--- a/src/swizzles/search/search.cpp
+++ b/src/swizzles/search/search.cpp
@@ -117,7 +117,7 @@ namespace swizzles::search {
         if (alpha >= beta) {
             if (move.captured() == chess::PieceType::None)
                 td.history_score[chess::index(pos.turn())][chess::index(move.from())][chess::index(move.to())] +=
-                    static_cast<int>(std::pow(2.0f, static_cast<float>(depth)));
+                    1ULL << depth;
             break;
         }
     }

--- a/src/swizzles/search/search.cpp
+++ b/src/swizzles/search/search.cpp
@@ -1,6 +1,5 @@
 #include "search.hpp"
 #include <chess/position.hpp>
-#include <cmath>
 #include <limits>
 #include <tt.hpp>
 #include "../eval/eval.hpp"

--- a/src/swizzles/search/search.cpp
+++ b/src/swizzles/search/search.cpp
@@ -117,7 +117,7 @@ namespace swizzles::search {
         if (alpha >= beta) {
             if (move.captured() == chess::PieceType::None)
                 td.history_score[chess::index(pos.turn())][chess::index(move.from())][chess::index(move.to())] +=
-                    static_cast<int>(std::pow(2, static_cast<float>(depth)));
+                    static_cast<int>(std::pow(2.0f, static_cast<float>(depth)));
             break;
         }
     }

--- a/src/swizzles/search/search.cpp
+++ b/src/swizzles/search/search.cpp
@@ -1,6 +1,6 @@
 #include "search.hpp"
-#include <math.h>
 #include <chess/position.hpp>
+#include <cmath>
 #include <limits>
 #include <tt.hpp>
 #include "../eval/eval.hpp"
@@ -53,7 +53,7 @@ namespace swizzles::search {
     }
 
     if (depth == 0 || ss->ply == max_depth) {
-        return qsearch(pos, alpha, beta, td);
+        return qsearch(td, pos, alpha, beta);
     }
 
     if (pos.halfmoves() >= 100) {
@@ -117,7 +117,7 @@ namespace swizzles::search {
         if (alpha >= beta) {
             if (move.captured() == chess::PieceType::None)
                 td.history_score[chess::index(pos.turn())][chess::index(move.from())][chess::index(move.to())] +=
-                    static_cast<int>(pow(2, static_cast<float>(depth)));
+                    static_cast<int>(std::pow(2, static_cast<float>(depth)));
             break;
         }
     }

--- a/src/swizzles/search/sort.cpp
+++ b/src/swizzles/search/sort.cpp
@@ -1,9 +1,10 @@
 #include "sort.hpp"
 #include <array>
-
+#include "search.hpp"
 namespace swizzles::search {
 
-auto sort(chess::MoveList &movelist, const chess::Move ttmove) noexcept -> void {
+auto sort(chess::MoveList &movelist, const chess::Move ttmove, const ThreadData &td, const chess::Colour turn) noexcept
+    -> void {
     if (movelist.empty()) {
         return;
     }
@@ -18,9 +19,17 @@ auto sort(chess::MoveList &movelist, const chess::Move ttmove) noexcept -> void 
     // Score
     for (std::size_t i = 0; i < movelist.size(); ++i) {
         if (movelist[i] == ttmove) {
-            scores[i] = 1'000'000;
+            scores[i] = 2'000'000;
+        } else if (movelist[i].captured() != chess::PieceType::None) {
+            scores[i] = 1'000'000 + mvvlva(movelist[i]);
         } else {
-            scores[i] = mvvlva(movelist[i]);
+            // history sorting
+            auto history_score =
+                td.history_score[chess::index(turn)][chess::index(movelist[i].from())][chess::index(movelist[i].to())];
+            if (history_score > 700'000) {
+                history_score = 700'000;
+            }
+            scores[i] = history_score;
         }
     }
 

--- a/src/swizzles/search/sort.cpp
+++ b/src/swizzles/search/sort.cpp
@@ -1,6 +1,7 @@
 #include "sort.hpp"
 #include <array>
 #include "search.hpp"
+
 namespace swizzles::search {
 
 auto sort(chess::MoveList &movelist, const chess::Move ttmove, const ThreadData &td, const chess::Colour turn) noexcept

--- a/src/swizzles/search/sort.cpp
+++ b/src/swizzles/search/sort.cpp
@@ -30,7 +30,7 @@ auto sort(chess::MoveList &movelist, const chess::Move ttmove, const ThreadData 
             if (history_score > 700'000) {
                 history_score = 700'000;
             }
-            scores[i] = history_score;
+            scores[i] = static_cast<int>(history_score);
         }
     }
 

--- a/src/swizzles/search/sort.hpp
+++ b/src/swizzles/search/sort.hpp
@@ -3,10 +3,12 @@
 
 #include <chess/move.hpp>
 #include <chess/movelist.hpp>
+#include "search.hpp"
 
 namespace swizzles::search {
 
-auto sort(chess::MoveList &movelist, const chess::Move ttmove) noexcept -> void;
+auto sort(chess::MoveList &movelist, const chess::Move ttmove, const ThreadData &td, const chess::Colour turn) noexcept
+    -> void;
 
 }  // namespace swizzles::search
 

--- a/src/swizzles/search/thread_data.hpp
+++ b/src/swizzles/search/thread_data.hpp
@@ -25,13 +25,6 @@ struct ThreadData {
             s.null_move = false;
             i++;
         }
-
-        for (int j = 0; j < 64; j++) {
-            for (int k = 0; k < 64; k++) {
-                history_score[index(chess::Colour::White)][j][k] = 0;
-                history_score[index(chess::Colour::Black)][j][k] = 0;
-            }
-        }
     }
 
     int id = 0;
@@ -39,7 +32,7 @@ struct ThreadData {
     int seldepth = 0;
     int tbhits = 0;
     std::array<SearchStack, max_depth + 1> stack;
-    int history_score[2][64][64];
+    int history_score[2][64][64] = {};
     SearchController *controller = nullptr;
     chess::Position pos;
     std::shared_ptr<TT<TTEntry>> tt;

--- a/src/swizzles/search/thread_data.hpp
+++ b/src/swizzles/search/thread_data.hpp
@@ -32,7 +32,7 @@ struct ThreadData {
     int seldepth = 0;
     int tbhits = 0;
     std::array<SearchStack, max_depth + 1> stack;
-    int history_score[2][64][64] = {};
+    std::uint64_t history_score[2][64][64] = {};
     SearchController *controller = nullptr;
     chess::Position pos;
     std::shared_ptr<TT<TTEntry>> tt;

--- a/src/swizzles/search/thread_data.hpp
+++ b/src/swizzles/search/thread_data.hpp
@@ -25,6 +25,13 @@ struct ThreadData {
             s.null_move = false;
             i++;
         }
+
+        for (int j = 0; j < 64; j++) {
+            for (int k = 0; k < 64; k++) {
+                history_score[index(chess::Colour::White)][j][k] = 0;
+                history_score[index(chess::Colour::Black)][j][k] = 0;
+            }
+        }
     }
 
     int id = 0;
@@ -32,6 +39,7 @@ struct ThreadData {
     int seldepth = 0;
     int tbhits = 0;
     std::array<SearchStack, max_depth + 1> stack;
+    int history_score[2][64][64];
     SearchController *controller = nullptr;
     chess::Position pos;
     std::shared_ptr<TT<TTEntry>> tt;


### PR DESCRIPTION
Score of swizzles_new vs swizzles_old: 214 - 133 - 128  [0.585] 475
Elo difference: 59.83 +/- 26.97
SPRT: llr 2.96, lbound -2.94, ubound 2.94 - H1 was accepted